### PR TITLE
CORS e Mongo atualização

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,18 +46,19 @@
         "eslint-import-resolver-typescript": "^2.0.0",
         "eslint-plugin-import": "^2.21.2",
         "eslint-plugin-prettier": "^3.1.4",
+        "husky": "^4.3.0",
         "jest": "^26.6.1",
+        "lint-staged": "^10.4.0",
         "prettier": "^2.0.5",
         "ts-jest": "^26.4.3",
         "ts-node": "^9.0.0",
         "ts-node-dev": "^1.0.0",
         "tsconfig-paths": "^3.9.0",
-        "typescript": "^4.0.3",
-        "husky": "^4.3.0",
-        "lint-staged": "^10.4.0"
+        "typescript": "^4.0.3"
     },
     "dependencies": {
         "axios": "^0.21.0",
+        "cors": "^2.8.5",
         "date-fns": "^2.16.1",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",

--- a/src/app/controllers/SearchRepositoryController.ts
+++ b/src/app/controllers/SearchRepositoryController.ts
@@ -7,6 +7,8 @@ import GitHubApi from '../lib/GitHubApi';
 
 class SearchRepositoryController {
     async index(request: Request, response: Response): Promise<Response> {
+        response.header('Access-Control-Allow-Origin', '*');
+
         const { project } = request.body;
         if (!project) throw new AppError('Project name is required', 422);
 

--- a/src/app/infra/config/index.ts
+++ b/src/app/infra/config/index.ts
@@ -12,6 +12,7 @@ class DataBase {
         this.mongoConnection = await mongoose.connect(
             `${process.env.MONGO_URL}`,
             {
+                useUnifiedTopology: true,
                 useNewUrlParser: true,
             },
         );

--- a/src/main/App.ts
+++ b/src/main/App.ts
@@ -1,11 +1,13 @@
 import 'reflect-metadata';
 import 'express-async-errors';
+import cors from 'cors';
 import express, { Request, Response, NextFunction } from 'express';
 import routes from './http/routes/index';
 import AppError from '../app/error/AppError';
 import '@infra/config/index';
 
 const app = express();
+app.use(cors());
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(routes);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2236,6 +2236,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cosmiconfig@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.0.tgz#ef9b44d773959cae63ddecd122de23853b60f8d3"
@@ -4886,7 +4894,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1:
+object-assign@^4, object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -6609,7 +6617,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
Quando tentei usar a API encontrei um problema comum que foi a falta de CORS, algo simples de resolver, então adicionei o mesmo com a opção de acesso total ( SearchRepositoryController.ts - linha:  10), para manter a conveniência de acesso livre e adicionei uma nova opção no mongo.connect ( useUnifiedTopology: true ) que sempre libera um warning após uma atualização do mongoose.